### PR TITLE
Update bzt.sh because of mktemp

### DIFF
--- a/test/nex-bzt.sh
+++ b/test/nex-bzt.sh
@@ -49,5 +49,5 @@ bzt -report -o scenarios.nex.default-address=${STD_APP_URL} \
     -o execution.0.hold-for=${HOLD} \
     -o execution.0.ramp-up=${RAMP_UP} \
     -o modules.console.disable=true \
-    -o settings.artifacts-dir=$(mktemp -d -t bzt) \
+    -o settings.artifacts-dir=$(mktemp -d -t bzt.XXXX) \
     ./test/nex-bzt.yml


### PR DESCRIPTION
In OSX, ```mktemp -d -t bzt``` gives you: ```/var/folders/z6/ckyqc_f92jvc6tjm0l5f033w0000gq/T/bzt.wiAAljeC```
but in Linux, you will get an error: ```mktemp: too few X's in template 'bzt'```

```mktemp -d -t bzt.XXXX``` will make it work for both OSX and Linux